### PR TITLE
Feature/launch tab with provided root

### DIFF
--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -529,8 +529,7 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
 
     /**
      * Completely empties the fragment/tag stack at the provided index and removes all fragments,
-     * then reinitializes the stack with the provided fragment
-     * (via [RootFragmentListener.getRootFragment])
+     * then re-initializes the stack with the parameter provided fragment
      *
      * **Note**: This is different than [clearStack], which clears out all the fragments in the
      * stack except for the root. It is also different from [emptyStackAndReinitialize]

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -509,6 +509,43 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
     }
 
     /**
+     * Completely empties the fragment/tag stack at the provided index and removes all fragments,
+     * then reinitializes the stack with the provided fragment
+     * (via [RootFragmentListener.getRootFragment])
+     *
+     * **Note**: This is different than [clearStack], which clears out all the fragments in the
+     * stack except for the root. It is also different from [emptyStackAndReinitialize]
+     * which clears out all of the fragments but then uses the [getRootFragment] call to initialize
+     * the stack with a root fragment provided by the callback.
+     */
+    fun emptyStackAndReinitializeWithNewBase(fragmentTransaction: FragmentTransaction, baseFragment: Fragment, stackIndex: Int) {
+        if (stackIndex == NO_TAB) {
+            return
+        }
+
+        //Grab Current stack
+        val fragmentStack = fragmentStacksTags[stackIndex]
+
+        //Pop all of the fragments on the stack and remove them from the FragmentManager
+        while (fragmentStack.size > 0) {
+            val fragment = fragmentManger.findFragmentByTag(fragmentStack.pop())
+            val ft = fragmentManger.beginTransaction()
+
+            if (fragment != null) {
+                ft.remove(fragment)
+            }
+
+            ft.commit()
+        }
+
+        val rootTag = generateTag(baseFragment)
+        fragmentStacksTags[stackIndex] = Stack()
+        fragmentStacksTags[stackIndex].push(rootTag)
+        fragmentTransaction.addSafe(containerId, baseFragment, rootTag)
+    }
+
+
+    /**
      * Replace the current fragment
      *
      * @param fragment           the fragment to be shown instead


### PR DESCRIPTION
This PR addresses the fact that previously, there was no way to affect the stack of the tab being switched to. Specifically in this case, the consumer of this library needs to be able to reset the stack of the destination tab and to provide a new root fragment with arguments so that the destination tab can utilize those arguments for further navigational purposes on that tab.

In the previous implementation, the tab would have to be switched, the callbacks would be made for the tab switch, a new fragment would need to be pushed onto the stack, and finally the stack would need to be reset with the current fragment as its new root. That last step's functionality was added previously by @erawhctim 

This implementation allows the consumer to switch tabs while providing fragment to use as the new root fragment rather than relying on the fragment provided through the `getRootFragment` function. In this way, a consumer can switch tabs and push a fragment on as the root fragment in one set of transitions rather than having them be disconnected by the tab transaction callback. 

This reduces the complication drastically for the consumer as all of the stack handling is done behind the API rather than the consumer needing to have the knowledge of what transactions are taking place.